### PR TITLE
Fix iOS user_off_route event detection

### DIFF
--- a/ios/Classes/NavigationFactory.swift
+++ b/ios/Classes/NavigationFactory.swift
@@ -439,6 +439,10 @@ extension NavigationFactory : NavigationViewControllerDelegate {
         return _shouldReRoute
     }
     
+    public func navigationViewController(_ navigationViewController: NavigationViewController, didRerouteFrom location: CLLocation) {
+        sendEvent(eventType: MapBoxEventType.user_off_route)
+    }
+    
     public func navigationViewController(_ navigationViewController: NavigationViewController, didSubmitArrivalFeedback feedback: EndOfRouteFeedback) {
         
         if(_eventSink != nil)


### PR DESCRIPTION
## Summary
- Fixes missing `user_off_route` event on iOS platform
- Adds the missing `navigationViewController(_:didRerouteFrom:)` delegate method
- Ensures iOS behavior matches Android off-route detection

## Problem
When using the flutter_mapbox_navigation package, off-route detection worked on Android but not on iOS. The `user_off_route` event was never triggered on iOS when users deviated from the planned route.

## Root Cause
The iOS implementation was missing the `navigationViewController(_:didRerouteFrom:)` delegate method that should send the `user_off_route` event when rerouting occurs.

## Solution
Added the missing delegate method to `NavigationFactory.swift`:
```swift
public func navigationViewController(_ navigationViewController: NavigationViewController, didRerouteFrom location: CLLocation) {
    sendEvent(eventType: MapBoxEventType.user_off_route)
}
```

## Test Plan
- [x] Build iOS app successfully
- [ ] Test navigation with route deviation on iOS device/simulator
- [ ] Verify `user_off_route` event is now triggered consistently
- [ ] Confirm behavior matches Android implementation

🤖 Generated with [Claude Code](https://claude.ai/code)